### PR TITLE
Fix: prefer CORS_ALLOWED_ORIGIN_REGEXES

### DIFF
--- a/server/alignmentapi/settings.py
+++ b/server/alignmentapi/settings.py
@@ -80,10 +80,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "alignmentapi.wsgi.application"
 
-CORS_ALLOWED_ORIGINS = [
-    "https://vocal-piroshki-b3c6dc.netlify.app",  # Alignment API Frontend
-    "http://localhost:8080",  # Local development
-    "https://deploy-preview-237--doric-symphony-preview.netlify.app",  # Symphony Browser Deploy Preview
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"https://vocal-piroshki-b3c6dc.netlify.app",  # Alignment API Frontend
+    r"http://localhost",  # Local development
+    r"https://(?P<subdomain>.+){0,1}doric-symphony-preview.netlify.app", # Symphony Browser Deploy Previews
+    r"https://labs.clear.bible",
 ]
 
 # Database


### PR DESCRIPTION
refs https://github.com/Clear-Bible/symphony-backend-atlas-internal/blob/e043ebcb4cf23039002137ce3b7c775937d4826c/atlas_framework/settings.py#L151

Will allow the API to work with multiple Netlify deploy previews and eventually the "production" instance on labs.clear.bible